### PR TITLE
DEVX-722 Debug mutimodal loader error 

### DIFF
--- a/requirements/extra-pdf-image.in
+++ b/requirements/extra-pdf-image.in
@@ -9,5 +9,6 @@ pypdf
 # Do not move to constraints.in, otherwise unstructured-inference will not be upgraded
 # when unstructured library is.
 unstructured-inference==0.7.36
+unstructured.pytesseract>=0.3.12
 # unstructured fork of pytesseract that provides an interface to allow for multiple output formats
 # from one tesseract call

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -278,7 +278,7 @@ tzdata==2024.1
     # via pandas
 unstructured-inference==0.7.36
     # via -r ./extra-pdf-image.in
-#unstructured-pytesseract==0.3.13
+unstructured-pytesseract==0.3.13
     # via -r ./extra-pdf-image.in
 urllib3==1.26.20
     # via

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -86,6 +86,7 @@ from unstructured.partition.utils.constants import (
     SORT_MODE_XY_CUT,
     OCRMode,
     PartitionStrategy,
+    OCR_AGENT_CLARIFAI,
 )
 from unstructured.partition.utils.sorting import coord_has_valid_points, sort_page_elements
 from unstructured.patches.pdfminer import parse_keyword
@@ -920,7 +921,8 @@ def _partition_pdf_or_image_with_ocr_from_image(
     """Extract `unstructured` elements from an image using OCR and perform partitioning."""
 
     from unstructured.partition.utils.ocr_models.ocr_interface import OCRAgent
-
+    
+    os.environ['OCR_AGENT'] = OCR_AGENT_CLARIFAI
     ocr_agent = OCRAgent.get_agent(language=ocr_languages)
 
     # NOTE(christine): `pytesseract.image_to_string()` returns sorted text

--- a/unstructured/partition/utils/ocr_models/ocr_interface.py
+++ b/unstructured/partition/utils/ocr_models/ocr_interface.py
@@ -31,7 +31,7 @@ class OCRAgent(ABC):
 
         The OCR package used by the agent is determined by the `OCR_AGENT` environment variable.
         """
-        ocr_agent_cls_qname = OCR_AGENT_CLARIFAI
+        ocr_agent_cls_qname = cls._get_ocr_agent_cls_qname()
         try:
             return cls.get_instance(ocr_agent_cls_qname, language)
         except (ImportError, AttributeError):


### PR DESCRIPTION
# What 
* Ticket - https://clarifai.atlassian.net/browse/DEVX-722
* Clarifai-unstructured fork is preventing the multimodal loader support feature within datautils.

# Why 
* Identified the issue is due to hardcoding the OCR agent in ocr_interface.py.
* By default the multimodal loader function utilises the unstructured_pytesseract to extract layout and process the PDF file.

# How
* Decoupled the OCR agent declaration, so that it will initialise only when partition function called with OCR_ONLY strategy.
* Added dependancy of pytesseract in requirements file.

### Issue log -
```
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/documents/elements.py:605 in       │
│ wrapper                                                                                          │
│                                                                                                  │
│    602 │   │                                                                                     │
│    603 │   │   @functools.wraps(func)                                                            │
│    604 │   │   def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> list[Element]:                │
│ ❱  605 │   │   │   elements = func(*args, **kwargs)                                              │
│    606 │   │   │   call_args = get_call_args_applying_defaults(func, *args, **kwargs)            │
│    607 │   │   │                                                                                 │
│    608 │   │   │   regex_metadata: dict["str", "str"] = call_args.get("regex_metadata", {})      │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/file_utils/filetype.py:731 in      │
│ wrapper                                                                                          │
│                                                                                                  │
│   728 │   def decorator(func: Callable[_P, list[Element]]) -> Callable[_P, list[Element]]:       │
│   729 │   │   @functools.wraps(func)                                                             │
│   730 │   │   def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> list[Element]:                 │
│ ❱ 731 │   │   │   elements = func(*args, **kwargs)                                               │
│   732 │   │   │   params = get_call_args_applying_defaults(func, *args, **kwargs)                │
│   733 │   │   │   include_metadata = params.get("include_metadata", True)                        │
│   734 │   │   │   if include_metadata:                                                           │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/file_utils/filetype.py:687 in      │
│ wrapper                                                                                          │
│                                                                                                  │
│   684 def add_metadata(func: Callable[_P, list[Element]]) -> Callable[_P, list[Element]]:        │
│   685 │   @functools.wraps(func)                                                                 │
│   686 │   def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> list[Element]:                     │
│ ❱ 687 │   │   elements = func(*args, **kwargs)                                                   │
│   688 │   │   call_args = get_call_args_applying_defaults(func, *args, **kwargs)                 │
│   689 │   │   include_metadata = call_args.get("include_metadata", True)                         │
│   690 │   │   if include_metadata:                                                               │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/chunking/dispatch.py:74 in wrapper │
│                                                                                                  │
│    71 │   │   """The decorated function is replaced with this one."""                            │
│    72 │   │                                                                                      │
│    73 │   │   # -- call the partitioning function to get the elements --                         │
│ ❱  74 │   │   elements = func(*args, **kwargs)                                                   │
│    75 │   │                                                                                      │
│    76 │   │   # -- look for a chunking-strategy argument --                                      │
│    77 │   │   call_args = get_call_args_applying_defaults(func, *args, **kwargs)                 │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/partition/pdf.py:208 in            │
│ partition_pdf                                                                                    │
│                                                                                                  │
│    205 │                                                                                         │
│    206 │   languages = check_language_args(languages or [], ocr_languages)                       │
│    207 │                                                                                         │
│ ❱  208 │   return partition_pdf_or_image(                                                        │
│    209 │   │   filename=filename,                                                                │
│    210 │   │   file=file,                                                                        │
│    211 │   │   include_page_breaks=include_page_breaks,                                          │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/partition/pdf.py:312 in            │
│ partition_pdf_or_image                                                                           │
│                                                                                                  │
│    309 │   │   # NOTE(robinson): Catches a UserWarning that occurs when detection is called      │
│    310 │   │   with warnings.catch_warnings():                                                   │
│    311 │   │   │   warnings.simplefilter("ignore")                                               │
│ ❱  312 │   │   │   elements = _partition_pdf_or_image_local(                                     │
│    313 │   │   │   │   filename=filename,                                                        │
│    314 │   │   │   │   file=spooled_to_bytes_io_if_needed(file),                                 │
│    315 │   │   │   │   is_image=is_image,                                                        │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/utils.py:217 in wrapper            │
│                                                                                                  │
│   214 │   │   @wraps(func)                                                                       │
│   215 │   │   def wrapper(*args: _P.args, **kwargs: _P.kwargs):                                  │
│   216 │   │   │   run_check()                                                                    │
│ ❱ 217 │   │   │   return func(*args, **kwargs)                                                   │
│   218 │   │                                                                                      │
│   219 │   │   @wraps(func)                                                                       │
│   220 │   │   async def wrapper_async(*args: _P.args, **kwargs: _P.kwargs):                      │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/partition/pdf.py:644 in            │
│ _partition_pdf_or_image_local                                                                    │
│                                                                                                  │
│    641 │   │   │   │   hi_res_model_name=hi_res_model_name,                                      │
│    642 │   │   │   )                                                                             │
│    643 │   │   │                                                                                 │
│ ❱  644 │   │   │   final_document_layout = process_file_with_ocr(                                │
│    645 │   │   │   │   filename,                                                                 │
│    646 │   │   │   │   merged_document_layout,                                                   │
│    647 │   │   │   │   extracted_layout=extracted_layout,                                        │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/utils.py:217 in wrapper            │
│                                                                                                  │
│   214 │   │   @wraps(func)                                                                       │
│   215 │   │   def wrapper(*args: _P.args, **kwargs: _P.kwargs):                                  │
│   216 │   │   │   run_check()                                                                    │
│ ❱ 217 │   │   │   return func(*args, **kwargs)                                                   │
│   218 │   │                                                                                      │
│   219 │   │   @wraps(func)                                                                       │
│   220 │   │   async def wrapper_async(*args: _P.args, **kwargs: _P.kwargs):                      │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/partition/pdf_image/ocr.py:178 in  │
│ process_file_with_ocr                                                                            │
│                                                                                                  │
│   175 │   │   │   │   return DocumentLayout.from_pages(merged_page_layouts)                      │
│   176 │   except Exception as e:                                                                 │
│   177 │   │   if os.path.isdir(filename) or os.path.isfile(filename):                            │
│ ❱ 178 │   │   │   raise e                                                                        │
│   179 │   │   else:                                                                              │
│   180 │   │   │   raise FileNotFoundError(f'File "{filename}" not found!') from e                │
│   181                                                                                            │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/partition/pdf_image/ocr.py:165 in  │
│ process_file_with_ocr                                                                            │
│                                                                                                  │
│   162 │   │   │   │   for i, image_path in enumerate(image_paths):                               │
│   163 │   │   │   │   │   extracted_regions = extracted_layout[i] if i < len(extracted_layout)   │
│   164 │   │   │   │   │   with PILImage.open(image_path) as image:                               │
│ ❱ 165 │   │   │   │   │   │   merged_page_layout = supplement_page_layout_with_ocr(              │
│   166 │   │   │   │   │   │   │   page_layout=out_layout.pages[i],                               │
│   167 │   │   │   │   │   │   │   image=image,                                                   │
│   168 │   │   │   │   │   │   │   infer_table_structure=infer_table_structure,                   │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/utils.py:217 in wrapper            │
│                                                                                                  │
│   214 │   │   @wraps(func)                                                                       │
│   215 │   │   def wrapper(*args: _P.args, **kwargs: _P.kwargs):                                  │
│   216 │   │   │   run_check()                                                                    │
│ ❱ 217 │   │   │   return func(*args, **kwargs)                                                   │
│   218 │   │                                                                                      │
│   219 │   │   @wraps(func)                                                                       │
│   220 │   │   async def wrapper_async(*args: _P.args, **kwargs: _P.kwargs):                      │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/partition/pdf_image/ocr.py:203 in  │
│ supplement_page_layout_with_ocr                                                                  │
│                                                                                                  │
│   200 │                                                                                          │
│   201 │   ocr_agent = OCRAgent.get_agent(language=ocr_languages)                                 │
│   202 │   if ocr_mode == OCRMode.FULL_PAGE.value:                                                │
│ ❱ 203 │   │   ocr_layout = ocr_agent.get_layout_from_image(image)                                │
│   204 │   │   if ocr_layout_dumper:                                                              │
│   205 │   │   │   ocr_layout_dumper.add_ocred_page(ocr_layout)                                   │
│   206 │   │   page_layout.elements[:] = merge_out_layout_with_ocr_layout(                        │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/unstructured/partition/utils/ocr_models/clarifa │
│ i_ocr.py:44 in get_layout_from_image                                                             │
│                                                                                                  │
│    41 │   │   logger.info("Processing entire page OCR with paddle...")                           │
│    42 │   │                                                                                      │
│    43 │   │   image_bytes = self.pil_image_to_bytes(image)                                       │
│ ❱  44 │   │   ocr_data = Model(clarifai_model_url).predict_by_bytes(image_bytes , input_type="   │
│    45 │   │   ocr_regions = self.parse_data(ocr_data)                                            │
│    46 │   │                                                                                      │
│    47 │   │   return ocr_regions                                                                 │
│                                                                                                  │
│ /home/vscode/.local/lib/python3.10/site-packages/clarifai/client/model.py:64 in __init__         │
│                                                                                                  │
│     61 │   if url and model_id:                                                                  │
│     62 │     raise UserError("You can only specify one of url or model_id.")                     │
│     63 │   if not url and not model_id:                                                          │
│ ❱   64 │     raise UserError("You must specify one of url or model_id.")                         │
│     65 │   if url:                                                                               │
│     66 │     user_id, app_id, _, model_id, model_version_id = ClarifaiUrlHelper.split_clarifai_  │
│     67 │     model_version = {'id': model_version_id}                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
UserError: You must specify one of url or model_id.```

